### PR TITLE
Added optional variable block size mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Usage: cannelloni -f <path> [more options]
   -2              -- Use double buffered FX2 fifo.
   -s              -- Run in sync slave fifo mode (default)
   -a              -- Run in async slave fifo mode.
-  -b N            -- Set IO buffer size to N bytes (default 16384), even from 2 to 2^31 -1.
+  -b N            -- Set IO buffer size to N bytes (default 16384), from 2 to 2^31 -1.
+  Note: if using 16 bit bus (option -w), N must be even.\n
+  -u              -- Use variable transfer block size
   -n M            -- Stop after M bytes, M being a number from 2 to 2^64 - 1.
   Note: M, if specified, must be divisible by N to avoid potential buffer overflow errors.
   -c [x|30[o]|48[o]][i] -- Specify interface clock:
@@ -117,6 +119,12 @@ Most program arguments are different from fx2pipe, though some are the same.
 - New option ```-j```: Invert polarity of 'SLOE' input pin (i.e. assert high)
 - New option ```-k```: Invert polarity of 'PKTEND' input flag pin (i.e. assert high)
 - Flag options (the ones without values) can be shortened together; i.e., ```-o -0 -w``` can be shortened to ```-o0w```
+
+## Variable block size protocol
+
+If ```-u``` is given as argument (only for output), the block size to be transferred is no longer constant. Instead, first a 32 bit word is transferred, which contains the number of bytes of the next data block to be output (1 to 2^32-1, "0" is reserved). That is, each block is preceded by a word that tells its size.
+
+The next block size (in bytes) must not exceed the block limit specified by ```-b``` option (or its default value), in bytes.
 
 ## Not implemented
 

--- a/src/cannelloni.c
+++ b/src/cannelloni.c
@@ -473,17 +473,17 @@ int main(int argc, char*argv[])
 		return print_usage(-1);
 	}
 
-	if ( use_variable_block_size ) {
-		if ( direction_in ) {
+	if (use_variable_block_size) {
+		if (direction_in) {
 			logerror("Option '-u' can only be used with output direction, please specify '-o'.\n");
 			return print_usage(-1);
 		}
-		if ( disable_in_out ) {
+		if (disable_in_out) {
 			logerror("Option '-u' cannot be used together with '-0' option.\n");
 			return print_usage(-1);
 		}
 	}
-	else if ( num_bytes_limit % block_size != 0 ) {
+	else if (num_bytes_limit % block_size != 0) {
 		logerror("Number of bytes to transfer (option '-b') must be divisible by buffer size (option -n)\n");
 		return print_usage(-1);
 	}
@@ -765,7 +765,7 @@ int main(int argc, char*argv[])
 	// Data transfer loop
 	while (!do_terminate) {
 
-		if ( ! use_variable_block_size ) num_bytes_to_transfer = block_size;
+		if (!use_variable_block_size) num_bytes_to_transfer = block_size;
 		else {
 
 			// Using variable block size. Read the 4-byte word containing size of next block in bytes.


### PR DESCRIPTION
This adds variable block size as an optional mode. See readme for explanation.

The use case is to allow sending different transfer sizes (small and big blocks) with delays in betweem them.

@jhol What do you think about this? Is it compatible with what you're working on?